### PR TITLE
Make FontFamily and FontSize used in popup configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Make FontFamily configurable
+- Make FontFamily and FontSize configurable
 - Added documentation about `timeout` and `timeoutlen`
 
 ## 0.2 - 2021-02-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Make FontFamily configurable
 - Added documentation about `timeout` and `timeoutlen`
 
 ## 0.2 - 2021-02-17

--- a/README.md
+++ b/README.md
@@ -112,15 +112,16 @@ let g:WhichKeyDesc_goto_top = "gg   goto first line"
 
 You can configure the appearance of certain UI elements by setting the following options:
 
-| Variable                  | Description                            | Values                                                                      | Default Value |
-|---------------------------|----------------------------------------|-----------------------------------------------------------------------------|---------------|
-| `g:WhichKey_Divider`      | String to separate key and description | any string                                                                  | ` → `         |
-| `g:WhichKey_KeyStyle`     | Font style for the keys                | `bold`, `italic`, `none`                                                    | `bold`        |
-| `g:WhichKey_KeyColor`     | Font color for the keys                | hex code or color keyword<br/>(`default`¹, `keyword`², "red", "blue", etc.) | `default`     |
-| `g:WhichKey_PrefixStyle`  | Font style for the prefixes            | `bold`, `italic`, `none`                                                    | `none`        |
-| `g:WhichKey_PrefixColor`  | Font color for the prefixes            | hex code or color keyword<br/>(`default`¹, `keyword`², "red", "blue", etc.) | `keyword`     |
-| `g:WhichKey_CommandStyle` | Font style for the commands            | `bold`, `italic`, `none`                                                    | `none`        |
-| `g:WhichKey_CommandColor` | Font color for the commands            | hex code or color keyword<br/>(`default`¹, `keyword`², "red", "blue", etc.) | `default`     |
+| Variable                  | Description                            | Values                                                                                       | Default Value |
+|---------------------------|----------------------------------------|----------------------------------------------------------------------------------------------|---------------|
+| `g:WhichKey_Divider`      | String to separate key and description | any string                                                                                   | ` → `         |
+| `g:WhichKey_FontFamily`   | Font to use for the popup              | CSS `font-family` (see [examples](https://www.w3schools.com/cssref/pr_font_font-family.asp)) | `monospace`   |
+| `g:WhichKey_KeyStyle`     | Font style for the keys                | `bold`, `italic`, `none`                                                                     | `bold`        |
+| `g:WhichKey_KeyColor`     | Font color for the keys                | hex code or color keyword<br/>(`default`¹, `keyword`², "red", "blue", etc.)                  | `default`     |
+| `g:WhichKey_PrefixStyle`  | Font style for the prefixes            | `bold`, `italic`, `none`                                                                     | `none`        |
+| `g:WhichKey_PrefixColor`  | Font color for the prefixes            | hex code or color keyword<br/>(`default`¹, `keyword`², "red", "blue", etc.)                  | `keyword`     |
+| `g:WhichKey_CommandStyle` | Font style for the commands            | `bold`, `italic`, `none`                                                                     | `none`        |
+| `g:WhichKey_CommandColor` | Font color for the commands            | hex code or color keyword<br/>(`default`¹, `keyword`², "red", "blue", etc.)                  | `default`     |
 
 ¹`default`: the default foreground color of the currently used theme  
 ²`keyword`: the color for "keywords" of the currently used theme

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ You can configure the appearance of certain UI elements by setting the following
 |---------------------------|----------------------------------------|----------------------------------------------------------------------------------------------|---------------|
 | `g:WhichKey_Divider`      | String to separate key and description | any string                                                                                   | ` → `         |
 | `g:WhichKey_FontFamily`   | Font to use for the popup              | CSS `font-family` (see [examples](https://www.w3schools.com/cssref/pr_font_font-family.asp)) | `monospace`   |
+| `g:WhichKey_FontSize`     | Font size for the popup                | Font size in `point` (for example `15`, `22`, etc.)                                          | IDE default³  |
 | `g:WhichKey_KeyStyle`     | Font style for the keys                | `bold`, `italic`, `none`                                                                     | `bold`        |
 | `g:WhichKey_KeyColor`     | Font color for the keys                | hex code or color keyword<br/>(`default`¹, `keyword`², "red", "blue", etc.)                  | `default`     |
 | `g:WhichKey_PrefixStyle`  | Font style for the prefixes            | `bold`, `italic`, `none`                                                                     | `none`        |
@@ -124,4 +125,5 @@ You can configure the appearance of certain UI elements by setting the following
 | `g:WhichKey_CommandColor` | Font color for the commands            | hex code or color keyword<br/>(`default`¹, `keyword`², "red", "blue", etc.)                  | `default`     |
 
 ¹`default`: the default foreground color of the currently used theme  
-²`keyword`: the color for "keywords" of the currently used theme
+²`keyword`: the color for "keywords" of the currently used theme  
+³Uses the IDE default value for the font size (without any configuration this should be `15`)

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/FormatConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/FormatConfig.kt
@@ -24,6 +24,14 @@ object FormatConfig {
         else -> escapeForHtml(div)
     }
 
+    private const val DEFAULT_FONT_FAMILY = "monospace" // the alignment works best with a monospaced font
+    private val fontFamily: String
+    get() = when (val font = VimScriptGlobalEnvironment.getInstance().variables["g:WhichKey_FontFamily"]) {
+        null -> DEFAULT_FONT_FAMILY
+        !is String -> DEFAULT_FONT_FAMILY
+        else -> font
+    }
+
     // configuration variables for the keys
     private val keyColor: String
     get() = when (val color = VimScriptGlobalEnvironment.getInstance().variables["g:WhichKey_KeyColor"]) {
@@ -123,7 +131,7 @@ object FormatConfig {
      * @return The built format string
      */
     private fun buildHtmlFormatString(tagName: String, color: String): String {
-        return "<$tagName style=\"color:$color;\">%s</$tagName>"
+        return "<$tagName style=\"font-family: $fontFamily; color:$color;\">%s</$tagName>"
     }
 
     /**

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/PopupConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/PopupConfig.kt
@@ -8,7 +8,6 @@ import com.maddyhome.idea.vim.option.OptionsManager
 import eu.theblob42.idea.whichkey.model.Mapping
 import kotlinx.coroutines.*
 import javax.swing.JFrame
-import javax.swing.JLabel
 import kotlin.math.ceil
 
 object PopupConfig {
@@ -51,14 +50,9 @@ object PopupConfig {
          */
         val frameWidth = (ideFrame.width * 0.65).toInt()
         // check for the longest string without HTML tags or styling (we have manually checked that 'nestedMappings' is not empty)
-        val maxString: String = nestedMappings.maxByOrNull { FormatConfig.formatRawMapping(it).length }!!.let {
-            FormatConfig.formatRawMapping(it)
-        }
-        /*
-         * there might be a better way to measure the pixel width of a given String than using a JLabel
-         * so far this method has worked quite well and since I'm missing a better alternative this stays for now
-         */
-        val maxStringWidth = JLabel(maxString).preferredSize.width
+        val maxMapping = nestedMappings.maxByOrNull { FormatConfig.calcRawMappingWidth(it) }!!
+        // calculate the pixel width of the longest mapping string (with styling)
+        val maxStringWidth = FormatConfig.calcFormattedMappingWidth(maxMapping)
         val possibleColumns = (frameWidth / maxStringWidth).let {
             if (it < 1) {
                 // ensure a minimum value of 1 to avoid dividing by zero


### PR DESCRIPTION
Resolves #2
 
Since the popup is using HTML to render its content we can use the CSS attribute 'font-family' to change the used font for keys and descriptions.

The default value is "monospace", since this ensures a nice alignment of keys, divider and description (except for special key strokes or modifiers).