### PR TITLE
Allow newer version including EAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.7.1
+
+### Changed
+
+- Update to work with version 2022.3
+
 ## 0.7.0
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.intellij.tasks.PatchPluginXmlTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -7,7 +8,7 @@ plugins {
 }
 
 group = "eu.theblob42.idea.whichkey"
-version = "0.7.0"
+version = "0.7.1"
 
 repositories {
     mavenCentral()
@@ -24,9 +25,14 @@ tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "11"
 }
 
+tasks.withType<PatchPluginXmlTask> {
+    sinceBuild.set("222")
+}
+
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     version.set("2022.2")
+    updateSinceUntilBuild.set(false)
     plugins.set(listOf("IdeaVIM:1.11.1"))
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,16 +29,14 @@
 
     <change-notes><![CDATA[
     <p>
-        <strong>0.7.0</strong>
+        <strong>0.7.1</strong>
     </p>
     <ul>
-        <li>update to work with intellij version 2022.2</li>
-        <li>update to work with IdeaVim version 1.11.1</li>
-        <li>remove all log4j dependencies</li>
+        <li>update to work with intellij version 2022.3</li>
     </ul>
     ]]></change-notes>
 
-    <version>0.7.0</version>
+    <version>0.7.1</version>
 
     <depends>com.intellij.modules.platform</depends>
     <depends>IdeaVIM</depends>


### PR DESCRIPTION
This PR should fix the issues that newer IDEs can't download this extension.

Have tested this in IntelliJ IDEA Ultimate Edition 2022.3 EAP