### PR TITLE
Update plugin to work with 2.8.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ intellij {
     }
     version.set("2023.3.2")
     updateSinceUntilBuild.set(false)
-    plugins.set(listOf("IdeaVIM:2.8.0-eap.1"))
+    plugins.set(listOf("IdeaVIM:2.8.0-eap.4"))
 }
 
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
-    kotlin("jvm") version "1.6.20"
-    id("org.jetbrains.intellij") version "1.8.0"
+    kotlin("jvm") version "1.9.22"
+    id("org.jetbrains.intellij") version "1.16.1"
 }
 
 group = "eu.theblob42.idea.whichkey"
@@ -26,14 +26,17 @@ tasks.withType<KotlinCompile> {
 }
 
 tasks.withType<PatchPluginXmlTask> {
-    sinceBuild.set("222")
+    sinceBuild.set("232")
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version.set("2022.2")
+    pluginsRepositories {
+        custom("https://plugins.jetbrains.com/plugins/eap/ideavim")
+    }
+    version.set("2023.3.2")
     updateSinceUntilBuild.set(false)
-    plugins.set(listOf("IdeaVIM:1.11.1"))
+    plugins.set(listOf("IdeaVIM:2.8.0-eap.1"))
 }
 
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,12 +31,9 @@ tasks.withType<PatchPluginXmlTask> {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    pluginsRepositories {
-        custom("https://plugins.jetbrains.com/plugins/eap/ideavim")
-    }
     version.set("2023.3.2")
     updateSinceUntilBuild.set(false)
-    plugins.set(listOf("IdeaVIM:2.8.0-eap.4"))
+    plugins.set(listOf("IdeaVIM:2.8.0"))
 }
 
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyShortcutKeyAction.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyShortcutKeyAction.kt
@@ -9,7 +9,8 @@ import com.maddyhome.idea.vim.action.VimShortcutKeyAction
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.CommandState
 import com.maddyhome.idea.vim.command.MappingMode
-import com.maddyhome.idea.vim.options.OptionScope
+import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.options.OptionAccessScope
 import eu.theblob42.idea.whichkey.config.MappingConfig
 import eu.theblob42.idea.whichkey.config.PopupConfig
 import java.awt.event.KeyEvent
@@ -33,31 +34,33 @@ class WhichKeyShortcutKeyAction: AnAction(), DumbAware {
     override fun actionPerformed(actionEvent: AnActionEvent) {
         PopupConfig.hidePopup()
 
-        if (injector.optionService.getOptionValue(OptionScope.GLOBAL, "which-key").asBoolean()) {
-            val editor = actionEvent.getData(PlatformDataKeys.EDITOR)
-            if (editor != null) {
-                val inputEvent = actionEvent.inputEvent
-                if (inputEvent is KeyEvent) {
-                    val startTime = System.currentTimeMillis() // save start time for the popup delay
+        val editor = actionEvent.getData(PlatformDataKeys.EDITOR)
+        val whichKeyOption = injector.optionGroup.getOption("which-key")
+        if (editor != null &&
+            whichKeyOption != null &&
+            injector.optionGroup.getOptionValue(whichKeyOption, OptionAccessScope.EFFECTIVE(editor.vim)).asBoolean()
+        ) {
+            val inputEvent = actionEvent.inputEvent
+            if (inputEvent is KeyEvent) {
+                val startTime = System.currentTimeMillis() // save start time for the popup delay
 
-                    val mappingState = CommandState.getInstance(editor).mappingState
-                    val typedKeySequence =
-                        mappingState.keys + listOf(KeyStroke.getKeyStroke(inputEvent.keyCode, inputEvent.modifiersEx))
-                    val nestedMappings = MappingConfig.getNestedMappings(mappingState.mappingMode, typedKeySequence)
-                    val window = WindowManager.getInstance().getFrame(editor.project)
+                val mappingState = CommandState.getInstance(editor).mappingState
+                val typedKeySequence =
+                    mappingState.keys + listOf(KeyStroke.getKeyStroke(inputEvent.keyCode, inputEvent.modifiersEx))
+                val nestedMappings = MappingConfig.getNestedMappings(mappingState.mappingMode, typedKeySequence)
+                val window = WindowManager.getInstance().getFrame(editor.project)
 
-                    if (nestedMappings.isEmpty()) {
-                        if (mappingState.mappingMode != MappingMode.INSERT
-                            && !MappingConfig.processWithUnknownMapping(mappingState.mappingMode, typedKeySequence)
-                        ) {
-                            // reset the mapping state, do not open a popup & ignore the next call to `update`
-                            mappingState.resetMappingSequence()
-                            ignoreNextUpdate = true
-                            return
-                        }
-                    } else {
-                        PopupConfig.showPopup(window!!, typedKeySequence, nestedMappings, startTime)
+                if (nestedMappings.isEmpty()) {
+                    if (mappingState.mappingMode != MappingMode.INSERT
+                        && !MappingConfig.processWithUnknownMapping(mappingState.mappingMode, typedKeySequence)
+                    ) {
+                        // reset the mapping state, do not open a popup & ignore the next call to `update`
+                        mappingState.resetMappingSequence()
+                        ignoreNextUpdate = true
+                        return
                     }
+                } else {
+                    PopupConfig.showPopup(window!!, typedKeySequence, nestedMappings, startTime)
                 }
             }
         }

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyTypeActionHandler.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyTypeActionHandler.kt
@@ -10,7 +10,8 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.CommandState
 import com.maddyhome.idea.vim.command.MappingMode
-import com.maddyhome.idea.vim.options.OptionScope
+import com.maddyhome.idea.vim.newapi.vim
+import com.maddyhome.idea.vim.options.OptionAccessScope
 import eu.theblob42.idea.whichkey.config.MappingConfig
 import eu.theblob42.idea.whichkey.config.PopupConfig
 import javax.swing.KeyStroke
@@ -30,7 +31,10 @@ class WhichKeyTypeActionHandler(private val vimTypedActionHandler: VimTypedActio
     override fun beforeExecute(editor: Editor, charTyped: Char, dataContext: DataContext, plan: ActionPlan) {
         PopupConfig.hidePopup()
 
-        if (injector.optionService.getOptionValue(OptionScope.GLOBAL, "which-key").asBoolean()) {
+        val whichKeyOption = injector.optionGroup.getOption("which-key")
+        if (whichKeyOption != null &&
+            injector.optionGroup.getOptionValue(whichKeyOption, OptionAccessScope.EFFECTIVE(editor.vim)).asBoolean()
+        ) {
             val commandState = CommandState.getInstance(editor)
             /*
              * check if the CommandBuilder is waiting for a DIGRAPH argument to the last typed action e.g. f<char>, t<char>, d<motion>

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/FormatConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/FormatConfig.kt
@@ -2,7 +2,7 @@ package eu.theblob42.idea.whichkey.config
 
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.TextAttributesKey
-import com.maddyhome.idea.vim.VimPlugin
+import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 import eu.theblob42.idea.whichkey.model.Mapping
@@ -22,7 +22,7 @@ object FormatConfig {
 
     private const val DEFAULT_DIVIDER = " → "
     private val divider: String
-    get() = when (val div = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_Divider")) {
+    get() = when (val div = injector.variableService.getGlobalVariableValue("WhichKey_Divider")) {
         null -> DEFAULT_DIVIDER
         !is VimString -> DEFAULT_DIVIDER
         else -> escapeForHtml(div.asString())
@@ -30,14 +30,14 @@ object FormatConfig {
 
     private const val DEFAULT_FONT_FAMILY = "monospace" // the alignment works best with a monospaced font
     private val fontFamily: String
-    get() = when (val font = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_FontFamily")) {
+    get() = when (val font = injector.variableService.getGlobalVariableValue("WhichKey_FontFamily")) {
         null -> DEFAULT_FONT_FAMILY
         !is VimString -> DEFAULT_FONT_FAMILY
         else -> font.asString()
     }
 
     private val fontSize: Int // font size in point
-    get() = when (val size = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_FontSize")) {
+    get() = when (val size = injector.variableService.getGlobalVariableValue("WhichKey_FontSize")) {
         // get default value from a "basic" JLabel
         null -> JLabel().font.size
         !is VimInt -> JLabel().font.size
@@ -46,7 +46,7 @@ object FormatConfig {
 
     // configuration variables for the keys
     private val keyColor: String
-    get() = when (val color = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_KeyColor")) {
+    get() = when (val color = injector.variableService.getGlobalVariableValue("WhichKey_KeyColor")) {
         // default color is the foreground color of the current theme
         null -> defaultForegroundColor
         !is VimString -> defaultForegroundColor
@@ -56,7 +56,7 @@ object FormatConfig {
     }
 
     private val keyStyle: String
-    get() = when (VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_KeyStyle")?.asString()) {
+    get() = when (injector.variableService.getGlobalVariableValue("WhichKey_KeyStyle")?.asString()) {
         "none" -> "span"
         "italic" -> "i"
         // default style is bold
@@ -65,7 +65,7 @@ object FormatConfig {
 
     // configuration variables for the description of commands
     private val descCommandColor: String
-    get() = when (val color = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_CommandColor")) {
+    get() = when (val color = injector.variableService.getGlobalVariableValue("WhichKey_CommandColor")) {
         // default color is the foreground color of the current theme
         null -> defaultForegroundColor
         !is VimString -> defaultForegroundColor
@@ -75,7 +75,7 @@ object FormatConfig {
     }
 
     private val descCommandStyle: String
-    get() = when (VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_CommandStyle")?.asString()) {
+    get() = when (injector.variableService.getGlobalVariableValue("WhichKey_CommandStyle")?.asString()) {
         "bold" -> "b"
         "italic" -> "i"
         // default style is none (nothing)
@@ -84,7 +84,7 @@ object FormatConfig {
 
     // configuration variables for the description of prefixes
     private val descPrefixColor: String
-    get() = when (val color = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_PrefixColor")) {
+    get() = when (val color = injector.variableService.getGlobalVariableValue("WhichKey_PrefixColor")) {
         // default color is the keyword color of the current theme
         null -> defaultKeywordColor
         !is VimString -> defaultKeywordColor
@@ -94,7 +94,7 @@ object FormatConfig {
     }
 
     private val descPrefixStyle: String
-    get() = when (VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_PrefixStyle")?.asString()) {
+    get() = when (injector.variableService.getGlobalVariableValue("WhichKey_PrefixStyle")?.asString()) {
         "bold" -> "b"
         "italic" -> "i"
         // default style is none (nothing)

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/MappingConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/MappingConfig.kt
@@ -70,7 +70,7 @@ object MappingConfig {
             return
         }
 
-        val actionId = (node as CommandNode<VimActionsInitiator>).actionHolder.ij.actionId
+        val actionId = (node as CommandNode<VimActionsInitiator>).actionHolder.getInstance().id
         vimActionsMap[keyStrokes] = actionId
     }
 

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/MappingConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/MappingConfig.kt
@@ -1,6 +1,6 @@
 package eu.theblob42.idea.whichkey.config
 
-import com.maddyhome.idea.vim.api.VimActionsInitiator
+import com.maddyhome.idea.vim.action.change.LazyVimCommand
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.DuplicableOperatorAction
@@ -59,8 +59,8 @@ object MappingConfig {
      * @param keyStrokes The [KeyStroke]s related to the given [node]
      * @param node The current mapping node
      */
-    private fun extractVimActions(vimActionsMap: MutableMap<List<KeyStroke>, String>, keyStrokes: List<KeyStroke>, node: Node<VimActionsInitiator>) {
-        if (node is CommandPartNode<VimActionsInitiator>) {
+    private fun extractVimActions(vimActionsMap: MutableMap<List<KeyStroke>, String>, keyStrokes: List<KeyStroke>, node: Node<LazyVimCommand>) {
+        if (node is CommandPartNode<LazyVimCommand>) {
             node.map {
                 val keys = keyStrokes + listOf(it.key)
                 extractVimActions(vimActionsMap, keys, it.value)
@@ -68,7 +68,7 @@ object MappingConfig {
             return
         }
 
-        val actionId = (node as CommandNode<VimActionsInitiator>).actionHolder.getInstance().id
+        val actionId = (node as CommandNode<LazyVimCommand>).actionHolder.instance.id
         vimActionsMap[keyStrokes] = actionId
     }
 
@@ -276,7 +276,7 @@ object MappingConfig {
         if (node.any {
             it.key == prefix.last()
                     && it.value is CommandNode
-                    && (it.value as CommandNode).actionHolder.getInstance().argumentType == Argument.Type.MOTION
+                    && (it.value as CommandNode).actionHolder.instance.argumentType == Argument.Type.MOTION
         }) {
             return true
         }
@@ -289,7 +289,7 @@ object MappingConfig {
                 && operatorNode.any {
                     it.key == keyStrokes.first()
                             && it.value is CommandNode
-                            && (it.value as CommandNode).actionHolder.getInstance() is DuplicableOperatorAction
+                            && (it.value as CommandNode).actionHolder.instance is DuplicableOperatorAction
                 }
         ) {
             return true

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/PopupConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/PopupConfig.kt
@@ -4,8 +4,8 @@ import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.ui.awt.RelativePoint
-import com.maddyhome.idea.vim.VimPlugin
-import com.maddyhome.idea.vim.options.OptionScope
+import com.maddyhome.idea.vim.api.globalOptions
+import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 import eu.theblob42.idea.whichkey.model.Mapping
@@ -19,7 +19,7 @@ object PopupConfig {
 
     private const val DEFAULT_POPUP_DELAY = 200
     private val defaultPopupDelay: Int
-    get() = when (val delay = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_DefaultDelay")) {
+    get() = when (val delay = injector.variableService.getGlobalVariableValue("WhichKey_DefaultDelay")) {
         null -> DEFAULT_POPUP_DELAY
         !is VimInt -> DEFAULT_POPUP_DELAY
         else -> delay.value
@@ -27,7 +27,7 @@ object PopupConfig {
 
     private val DEFAULT_SORT_OPTION = SortOption.BY_KEY
     private val sortOption: SortOption
-    get() = when (val option = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_SortOrder")) {
+    get() = when (val option = injector.variableService.getGlobalVariableValue("WhichKey_SortOrder")) {
         null -> DEFAULT_SORT_OPTION
         !is VimString -> DEFAULT_SORT_OPTION
         else -> SortOption.values().firstOrNull { it.name.equals(option.asString(), ignoreCase = true) } ?: DEFAULT_SORT_OPTION
@@ -35,7 +35,7 @@ object PopupConfig {
 
     private const val DEFAULT_SORT_CASE_SENSITIVE = true
     private val sortCaseSensitive: Boolean
-    get() = when (val option = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_SortCaseSensitive")) {
+    get() = when (val option = injector.variableService.getGlobalVariableValue("WhichKey_SortCaseSensitive")) {
         null -> DEFAULT_SORT_CASE_SENSITIVE
         !is VimString -> DEFAULT_SORT_CASE_SENSITIVE
         else -> option.asString().toBoolean()
@@ -117,7 +117,7 @@ object PopupConfig {
         mappingsStringBuilder.append("</table>")
 
         // append the already typed key sequence below the nested mappings table if configured (default: true)
-        val showTypedSequence = when (val show = VimPlugin.getVariableService().getGlobalVariableValue("WhichKey_ShowTypedSequence")) {
+        val showTypedSequence = when (val show = injector.variableService.getGlobalVariableValue("WhichKey_ShowTypedSequence")) {
             null -> true
             !is VimString -> true
             else -> show.asString().toBoolean()
@@ -128,8 +128,8 @@ object PopupConfig {
         }
 
         val target = RelativePoint.getSouthWestOf(ideFrame.rootPane)
-        val fadeoutTime = if (VimPlugin.getOptionService().getOptionValue(OptionScope.GLOBAL, "timeout").asBoolean()) {
-            VimPlugin.getOptionService().getOptionValue(OptionScope.GLOBAL, "timeoutlen").asDouble().toLong()
+        val fadeoutTime = if (injector.globalOptions().timeout) {
+            injector.globalOptions().timeoutlen.toLong()
         } else {
             0L
         }


### PR DESCRIPTION
I've minimized the use of deprecated APIs as much as possible. I plan to create one more pull request after removing `VimActionsInitiator `and transitioning fully to `LazyVimCommand`. Additionally, this PR utilizes the EAP version and the plugin repository for compilation purposes. This should be switched to the stable 2.8.0 version once it's released. Therefore, I suggest waiting for the 2.8.0 release before making any further changes or releases of the plugin.