### PR TITLE
Allow setting descriptions for built-in vim commands

### DIFF
--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/MappingConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/MappingConfig.kt
@@ -160,11 +160,11 @@ object MappingConfig {
             is VimString -> value.asString().toBoolean()
             else -> false
         }
-        val vimActionsPairs = if (showVimActions) {
-                VIM_ACTIONS[mode]?.entries
-                    ?.map { it.toPair() }
-                    ?: listOf()
-        } else listOf()
+        val vimActionsPairs =
+            VIM_ACTIONS[mode]?.entries
+                ?.map { it.key to if (showVimActions) it.value else "" }
+                ?: listOf()
+
 
         val nestedMappings = mutableMapOf<String, Mapping>()
         for ((mappedKeyStrokes, defaultDescription) in (keyMappingPairs + vimActionsPairs)) {


### PR DESCRIPTION
without having to show each and every possible vim command there is.

The behaviour when `g:WhichKey_ShowVimActions` is `true` is unchanged, but if it is not `true``, the new behaviour includes all built-in commands that the user set a description for (otherwise the command is not shown because the description is empty).

This allows for users to selectively enable showing hints for certain built-in vim commands without cluttering the which-key pop-up.