### PR TITLE
Migrate to gradle plugin v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .gradle/
 build/
 out/
+.intellijPlatform

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,8 @@
-import org.jetbrains.intellij.tasks.PatchPluginXmlTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
     kotlin("jvm") version "1.9.22"
-    id("org.jetbrains.intellij") version "1.16.1"
+    id("org.jetbrains.intellij.platform") version "2.3.0"
 }
 
 group = "eu.theblob42.idea.whichkey"
@@ -12,6 +10,9 @@ version = "0.10.3"
 
 repositories {
     mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 dependencies {
@@ -19,19 +20,52 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4")
 
     testImplementation("junit", "junit", "4.12")
+
+    intellijPlatform {
+        intellijIdeaCommunity("2023.3.3")
+        pluginVerifier()
+        plugins("IdeaVIM:2.10.0")
+    }
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "17"
+intellijPlatform {
+    pluginConfiguration {
+        ideaVersion {
+            // Let the Gradle plugin set the since-build version. It defaults to the version of the IDE we're building against
+            // specified as two components, `{branch}.{build}` (e.g., "241.15989"). There is no third component specified.
+            // The until-build version defaults to `{branch}.*`, but we want to support _all_ future versions, so we set it
+            // with a null provider (the provider is important).
+            // By letting the Gradle plugin handle this, the Plugin DevKit IntelliJ plugin cannot help us with the "Usage of
+            // IntelliJ API not available in older IDEs" inspection. However, since our since-build is the version we compile
+            // against, we can never get an API that's newer - it would be an unresolved symbol.
+            untilBuild.set(provider { null })
+        }
+    }
+
 }
 
-tasks.withType<PatchPluginXmlTask> {
-    sinceBuild.set("233")
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
 }
 
-// See https://github.com/JetBrains/gradle-intellij-plugin/
-intellij {
-    version.set("2023.3.3")
-    updateSinceUntilBuild.set(false)
-    plugins.set(listOf("IdeaVIM:2.10.0"))
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+tasks {
+    compileKotlin {
+        kotlinOptions {
+            jvmTarget = "17"
+        }
+    }
+
+    compileTestKotlin {
+        kotlinOptions {
+            jvmTarget = "17"
+        }
+    }
 }


### PR DESCRIPTION
Hi, I took the time to move away from the now unsupported v1 gradle api.

Doesn't seem to bring many benefits that I can see, but in their blogpost they say migrating is important :P

https://blog.jetbrains.com/platform/2024/07/intellij-platform-gradle-plugin-2-0/

It also fixes an error that I had on my machine with kotlin/java having different jvm versions specified.