### PR TITLE
Add new Pop-up implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "eu.theblob42.idea.whichkey"
-version = "0.11.2"
+version = "0.12.0-preview2"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyActionListener.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyActionListener.kt
@@ -17,8 +17,8 @@ import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.impl.state.toMappingMode
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.options.OptionAccessScope
-import eu.theblob42.idea.whichkey.config.DefaultPopupProvider
 import eu.theblob42.idea.whichkey.config.MappingConfig
+import eu.theblob42.idea.whichkey.config.NewPopupProvider
 import eu.theblob42.idea.whichkey.model.Mapping
 import eu.theblob42.idea.whichkey.provider.DebouncingPopupProvider
 import java.awt.event.KeyEvent
@@ -37,7 +37,7 @@ class BlockNextTypedActionHandler(private val originalHandler: TypedActionHandle
 }
 
 class WhichKeyActionListener : AnActionListener {
-    private val popupProvider = DebouncingPopupProvider(DefaultPopupProvider())
+    private val popupProvider = DebouncingPopupProvider(NewPopupProvider())
     private var blockNextAction: Boolean = false
 
     override fun afterActionPerformed(action: AnAction, event: AnActionEvent, result: AnActionResult) {

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyActionListener.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyActionListener.kt
@@ -18,9 +18,8 @@ import com.maddyhome.idea.vim.impl.state.toMappingMode
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.options.OptionAccessScope
 import eu.theblob42.idea.whichkey.config.MappingConfig
-import eu.theblob42.idea.whichkey.config.NewPopupProvider
 import eu.theblob42.idea.whichkey.model.Mapping
-import eu.theblob42.idea.whichkey.provider.DebouncingPopupProvider
+import eu.theblob42.idea.whichkey.provider.ConfigurablePopupProvider
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
@@ -37,7 +36,7 @@ class BlockNextTypedActionHandler(private val originalHandler: TypedActionHandle
 }
 
 class WhichKeyActionListener : AnActionListener {
-    private val popupProvider = DebouncingPopupProvider(NewPopupProvider())
+    private val popupProvider = ConfigurablePopupProvider()
     private var blockNextAction: Boolean = false
 
     override fun afterActionPerformed(action: AnAction, event: AnActionEvent, result: AnActionResult) {

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyActionListener.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyActionListener.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.editor.actionSystem.ActionPlan
 import com.intellij.openapi.editor.actionSystem.TypedAction
 import com.intellij.openapi.editor.actionSystem.TypedActionHandler
 import com.intellij.openapi.editor.actionSystem.TypedActionHandlerEx
-import com.intellij.openapi.wm.WindowManager
 import com.maddyhome.idea.vim.KeyHandler
 import com.maddyhome.idea.vim.api.VimEditor
 import com.maddyhome.idea.vim.api.injector
@@ -18,9 +17,10 @@ import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.impl.state.toMappingMode
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.options.OptionAccessScope
+import eu.theblob42.idea.whichkey.config.DefaultPopupProvider
 import eu.theblob42.idea.whichkey.config.MappingConfig
-import eu.theblob42.idea.whichkey.config.PopupConfig
 import eu.theblob42.idea.whichkey.model.Mapping
+import eu.theblob42.idea.whichkey.provider.DebouncingPopupProvider
 import java.awt.event.KeyEvent
 import javax.swing.KeyStroke
 
@@ -37,6 +37,7 @@ class BlockNextTypedActionHandler(private val originalHandler: TypedActionHandle
 }
 
 class WhichKeyActionListener : AnActionListener {
+    private val popupProvider = DebouncingPopupProvider(DefaultPopupProvider())
     private var blockNextAction: Boolean = false
 
     override fun afterActionPerformed(action: AnAction, event: AnActionEvent, result: AnActionResult) {
@@ -59,7 +60,7 @@ class WhichKeyActionListener : AnActionListener {
         actions: MutableList<AnAction>,
         dataContext: DataContext
     ) {
-        PopupConfig.hidePopup()
+        popupProvider.hidePopup()
         if (shortcut !is KeyboardShortcut) {
             return
         }
@@ -93,8 +94,7 @@ class WhichKeyActionListener : AnActionListener {
     }
 
     override fun beforeEditorTyping(charTyped: Char, dataContext: DataContext) {
-        PopupConfig.hidePopup()
-
+        popupProvider.hidePopup()
         val editor = dataContext.getData(CommonDataKeys.EDITOR) ?: return
         if (!EditorHelper.isFileEditor(editor)) {
             return
@@ -120,7 +120,6 @@ class WhichKeyActionListener : AnActionListener {
         val mappingMode = vimEditor.mode.toMappingMode()
         val mappingState = KeyHandler.getInstance().keyHandlerState.mappingState
         val nestedMappings = getMappingsToDisplay(editor, typedKeySequence)
-        val window = WindowManager.getInstance().getFrame(editor.project)
 
         if (nestedMappings.isEmpty()) {
             // insert mode "inserts" unmapped chars which we don't want to block
@@ -138,7 +137,7 @@ class WhichKeyActionListener : AnActionListener {
                 return blockNextKeyPress(isShortcut, vimEditor, mappingState)
             }
         } else {
-            PopupConfig.showPopup(window!!, typedKeySequence, nestedMappings, startTime)
+            popupProvider.showPopup(editor, typedKeySequence, nestedMappings, startTime)
         }
     }
 

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/DefaultPopupProvider.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/DefaultPopupProvider.kt
@@ -1,57 +1,30 @@
 package eu.theblob42.idea.whichkey.config
 
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.awt.RelativePoint
 import com.maddyhome.idea.vim.api.globalOptions
 import com.maddyhome.idea.vim.api.injector
-import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 import eu.theblob42.idea.whichkey.model.Mapping
+import eu.theblob42.idea.whichkey.model.Mappings
+import eu.theblob42.idea.whichkey.provider.PopupProvider
 import kotlinx.coroutines.*
 import javax.swing.JFrame
 import javax.swing.JLabel
 import javax.swing.KeyStroke
 import kotlin.math.ceil
 
-object PopupConfig {
-
-    private const val DEFAULT_POPUP_DELAY = 200
-    private val defaultPopupDelay: Int
-    get() = when (val delay = injector.variableService.getGlobalVariableValue("WhichKey_DefaultDelay")) {
-        null -> DEFAULT_POPUP_DELAY
-        !is VimInt -> DEFAULT_POPUP_DELAY
-        else -> delay.value
-    }
-
-    private val DEFAULT_SORT_OPTION = SortOption.BY_KEY
-    private val sortOption: SortOption
-    get() = when (val option = injector.variableService.getGlobalVariableValue("WhichKey_SortOrder")) {
-        null -> DEFAULT_SORT_OPTION
-        !is VimString -> DEFAULT_SORT_OPTION
-        else -> SortOption.values().firstOrNull { it.name.equals(option.asString(), ignoreCase = true) } ?: DEFAULT_SORT_OPTION
-    }
-
-    private const val DEFAULT_SORT_CASE_SENSITIVE = true
-    private val sortCaseSensitive: Boolean
-    get() = when (val option = injector.variableService.getGlobalVariableValue("WhichKey_SortCaseSensitive")) {
-        null -> DEFAULT_SORT_CASE_SENSITIVE
-        !is VimString -> DEFAULT_SORT_CASE_SENSITIVE
-        else -> option.asString().toBoolean()
-    }
-
+class DefaultPopupProvider : PopupProvider {
     private var currentBalloon: Balloon? = null
-    private var displayBalloonJob: Job? = null
 
     /**
      * Either cancel the display job or hide the current popup
      */
-    fun hidePopup() {
-        // cancel job or wait till it's done (if it already started)
-        runBlocking {
-            displayBalloonJob?.cancelAndJoin()
-        }
+    override fun hidePopup() {
         // hide Balloon if present and reset value
         currentBalloon?.let {
             it.hide()
@@ -70,19 +43,20 @@ object PopupConfig {
      * @param nestedMappings A [List] of nested mappings to display
      * @param startTime Timestamp to consider for the calculation of the popup delay
      */
-    @OptIn(DelicateCoroutinesApi::class)
-    fun showPopup(ideFrame: JFrame, typedKeys: List<KeyStroke>, nestedMappings: List<Pair<String, Mapping>>, startTime: Long) {
+    override fun showPopup(editor: Editor, typedKeys: List<KeyStroke>, nestedMappings: List<Pair<String, Mapping>>) {
         if (nestedMappings.isEmpty()) {
             return
         }
 
+        val ideFrame = WindowManager.getInstance().getFrame(editor.project)!!
         /*
          * the factor 0.65 was found by experimenting and comparing result lengths pixel by pixel
          * it might be erroneous and could change in the future
          */
         val frameWidth = (ideFrame.width * 0.65).toInt()
         // check for the longest string as this will most probably be the widest mapping
-        val maxMapping = nestedMappings.maxByOrNull { (key, mapping) -> key.length + mapping.description.length }!! // (we have manually checked that 'nestedMappings' is not empty)
+        val maxMapping =
+            nestedMappings.maxByOrNull { (key, mapping) -> key.length + mapping.description.length }!! // (we have manually checked that 'nestedMappings' is not empty)
         // calculate the pixel width of the longest mapping string (with HTML formatting & styling)
         val maxStringWidth = JLabel("<html>${FormatConfig.formatMappingEntry(maxMapping)}</html>").preferredSize.width
         val possibleColumns = (frameWidth / maxStringWidth).let {
@@ -98,7 +72,7 @@ object PopupConfig {
         val columnWidth = frameWidth / possibleColumns
 
         val elementsPerColumn = ceil(nestedMappings.size / possibleColumns.toDouble()).toInt()
-        val windowedMappings = sortMappings(nestedMappings)
+        val windowedMappings = Mappings.sort(nestedMappings)
             .map(FormatConfig::formatMappingEntry)
             .windowed(elementsPerColumn, elementsPerColumn, true)
 
@@ -118,11 +92,12 @@ object PopupConfig {
         mappingsStringBuilder.append("</table>")
 
         // append the already typed key sequence below the nested mappings table if configured (default: true)
-        val showTypedSequence = when (val show = injector.variableService.getGlobalVariableValue("WhichKey_ShowTypedSequence")) {
-            null -> true
-            !is VimString -> true
-            else -> show.asString().toBoolean()
-        }
+        val showTypedSequence =
+            when (val show = injector.variableService.getGlobalVariableValue("WhichKey_ShowTypedSequence")) {
+                null -> true
+                !is VimString -> true
+                else -> show.asString().toBoolean()
+            }
         if (showTypedSequence) {
             mappingsStringBuilder.append("<hr style=\"margin-bottom: 2px;\">") // some small margin to not look cramped
             mappingsStringBuilder.append(FormatConfig.formatTypedSequence(typedKeys))
@@ -138,47 +113,17 @@ object PopupConfig {
         // the extra variable 'newWhichKeyBalloon' is needed so that the currently displayed Balloon
         // can be hidden in case the 'displayBalloonJob' gets canceled before execution
         val newWhichKeyBalloon = JBPopupFactory.getInstance()
-            .createHtmlTextBalloonBuilder(mappingsStringBuilder.toString(), null, EditorColorsManager.getInstance().schemeForCurrentUITheme.defaultBackground, null)
+            .createHtmlTextBalloonBuilder(
+                mappingsStringBuilder.toString(),
+                null,
+                EditorColorsManager.getInstance().schemeForCurrentUITheme.defaultBackground,
+                null
+            )
             .setAnimationCycle(10) // shorten animation time
             .setFadeoutTime(fadeoutTime)
             .createBalloon()
 
-        /*
-         * wait for a few ms before showing the Balloon to prevent flickering on fast consecutive key presses
-         * subtract the already passed time (for calculations etc.) to make the delay as consistent as possible
-         */
-        val delay = (defaultPopupDelay - (System.currentTimeMillis() - startTime)).let {
-            if (it < 0) 0 else it
-        }
-
-        displayBalloonJob = GlobalScope.launch {
-            delay(delay)
-            newWhichKeyBalloon.show(target, Balloon.Position.above)
-            currentBalloon = newWhichKeyBalloon
-        }
+        newWhichKeyBalloon.show(target, Balloon.Position.above)
+        currentBalloon = newWhichKeyBalloon
     }
-
-    /**
-     * Sort mappings dependent on the configured sort options
-     * @param nestedMappings The list of mappings to sort
-     * @return The sorted list of mappings
-     */
-    private fun sortMappings(nestedMappings: List<Pair<String, Mapping>>): List<Pair<String, Mapping>> {
-        // String::compareTo is by default case-sensitive
-        val cmp = if (sortCaseSensitive) String::compareTo else String.CASE_INSENSITIVE_ORDER::compare
-
-        return when (sortOption) {
-            SortOption.BY_KEY -> nestedMappings.sortedWith(compareBy(cmp) { it.first })
-            SortOption.BY_KEY_PREFIX_FIRST -> nestedMappings.sortedWith(compareBy<Pair<String, Mapping>> { !it.second.prefix }.thenBy(cmp) { it.first })
-            SortOption.BY_KEY_PREFIX_LAST -> nestedMappings.sortedWith(compareBy<Pair<String, Mapping>> { it.second.prefix }.thenBy(cmp) { it.first })
-            SortOption.BY_DESCRIPTION -> nestedMappings.sortedWith(compareBy(cmp) { it.second.description })
-        }
-    }
-}
-
-enum class SortOption {
-    BY_KEY,
-    BY_KEY_PREFIX_FIRST,
-    BY_KEY_PREFIX_LAST,
-    BY_DESCRIPTION
 }

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/DefaultPopupProvider.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/DefaultPopupProvider.kt
@@ -22,7 +22,7 @@ class DefaultPopupProvider : PopupProvider {
     private var currentBalloon: Balloon? = null
 
     /**
-     * Either cancel the display job or hide the current popup
+     * Hide the current popup
      */
     override fun hidePopup() {
         // hide Balloon if present and reset value
@@ -43,7 +43,7 @@ class DefaultPopupProvider : PopupProvider {
      * @param nestedMappings A [List] of nested mappings to display
      * @param startTime Timestamp to consider for the calculation of the popup delay
      */
-    override fun showPopup(editor: Editor, typedKeys: List<KeyStroke>, nestedMappings: List<Pair<String, Mapping>>) {
+    override fun showPopup(editor: Editor, typedKeys: List<KeyStroke>, nestedMappings: List<Pair<String, Mapping>>, startTime: Long) {
         if (nestedMappings.isEmpty()) {
             return
         }

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/NewPopupProvider.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/NewPopupProvider.kt
@@ -11,9 +11,11 @@ import java.awt.*
 import javax.swing.*
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.ui.popup.*
+import com.intellij.util.ui.UIUtil
 import eu.theblob42.idea.whichkey.model.Mappings
 import eu.theblob42.idea.whichkey.provider.PopupProvider
 import java.awt.event.KeyEvent
+import kotlin.math.ceil
 
 val WHICHKEY_MAPPING_BINDING =
     TextAttributesKey.createTextAttributesKey("WHICHKEY_MAPPING_BINDING", DefaultLanguageHighlighterColors.NUMBER)
@@ -37,7 +39,14 @@ class NewPopupProvider: PopupProvider {
         currentPopup = null
     }
 
-    private fun show(editor: Editor, text: TextWithHighlights) {
+    private fun show(editor: Editor, items: List<Item>) {
+        val style = Style.RIGHT
+        val rowWidth = 40
+        val containerWidth = if (style == Style.RIGHT) rowWidth else editor.calculateSizeInCharacters()?.width ?: 50
+
+        val text = PopupLayout.layoutItems(
+            40, containerWidth, WhichKeyConfig(), items
+        )
         val editorFactory: EditorFactory = EditorFactory.getInstance()
         val document = editorFactory.createDocument(text.text)
         val editor2: Editor = editorFactory.createViewer(document)
@@ -66,6 +75,13 @@ class NewPopupProvider: PopupProvider {
 
         val contentSize = editor.component.visibleRect.size
         val popupHeight = lines.size * editor.lineHeight
+
+
+        val preferredSize = when(style){
+            Style.BOTTOM -> Dimension(contentSize.width, popupHeight)
+            Style.RIGHT -> Dimension(rowWidth * ceil(editor.getCharSize().width).toInt(), popupHeight)
+        }
+
         val component = object : JComponent() {
             init {
                 layout = BorderLayout()
@@ -74,7 +90,7 @@ class NewPopupProvider: PopupProvider {
                     verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_NEVER
                     horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
                 }
-                scrollPane.preferredSize = Dimension(contentSize.width, popupHeight)
+                scrollPane.preferredSize = preferredSize
                 add(scrollPane, BorderLayout.CENTER)
             }
         }
@@ -99,7 +115,15 @@ class NewPopupProvider: PopupProvider {
 //                }
 //            })
             .createPopup()
-        popup.show(RelativePoint(editor.component, Point(0, contentSize.height - popupHeight)))
+        when(style) {
+            Style.BOTTOM ->
+                popup.show(RelativePoint(editor.component, Point(0, contentSize.height - popupHeight)))
+
+            Style.RIGHT -> {
+                val scrollbarPadding = UIUtil.getScrollBarWidth()
+                popup.show(RelativePoint(editor.component, Point(contentSize.width-preferredSize.width - scrollbarPadding, contentSize.height - popupHeight - scrollbarPadding)))
+            }
+        }
         currentPopup = popup
     }
 
@@ -151,10 +175,11 @@ class NewPopupProvider: PopupProvider {
                 it.second.prefix
             )
         }
-        val text = PopupLayout.layoutItems(
-            40, editor.calculateSizeInCharacters()?.width ?: 50, WhichKeyConfig(), items
-        )
-        show(editor, text)
-        return
+
+        show(editor, items)
+    }
+    enum class Style {
+        BOTTOM,
+        RIGHT
     }
 }

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/NewPopupProvider.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/NewPopupProvider.kt
@@ -1,0 +1,160 @@
+package eu.theblob42.idea.whichkey.config
+
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.ui.ScrollPaneFactory
+import com.intellij.ui.awt.RelativePoint
+import com.maddyhome.idea.vim.api.injector
+import eu.theblob42.idea.whichkey.model.Mapping
+import java.awt.*
+import javax.swing.*
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.ui.popup.*
+import eu.theblob42.idea.whichkey.model.Mappings
+import eu.theblob42.idea.whichkey.provider.PopupProvider
+import java.awt.event.KeyEvent
+
+val WHICHKEY_MAPPING_BINDING =
+    TextAttributesKey.createTextAttributesKey("WHICHKEY_MAPPING_BINDING", DefaultLanguageHighlighterColors.NUMBER)
+val WHICHKEY_MAPPING_ASSIGMENT =
+    TextAttributesKey.createTextAttributesKey("WHICHKEY_MAPPING_ASSIGMENT", DefaultLanguageHighlighterColors.CONSTANT)
+val WHICHKEY_MAPPING_ICON =
+    TextAttributesKey.createTextAttributesKey("WHICHKEY_MAPPING_ICON", DefaultLanguageHighlighterColors.CONSTANT)
+val WHICHKEY_MAPPING_DESCRIPTION = TextAttributesKey.createTextAttributesKey(
+    "WHICHKEY_MAPPING_DESCRIPTION",
+    DefaultLanguageHighlighterColors.LINE_COMMENT
+)
+val WHICHKEY_MAPPING_DESCRIPTION_GROUP = TextAttributesKey.createTextAttributesKey(
+    "WHICHKEY_MAPPING_DESCRIPTION_GROUP",
+    DefaultLanguageHighlighterColors.KEYWORD
+)
+
+class NewPopupProvider: PopupProvider {
+    private var currentPopup: JBPopup? = null
+    override fun hidePopup() {
+        currentPopup?.cancel()
+        currentPopup = null
+    }
+
+    private fun show(editor: Editor, text: TextWithHighlights) {
+        val editorFactory: EditorFactory = EditorFactory.getInstance()
+        val document = editorFactory.createDocument(text.text)
+        val editor2: Editor = editorFactory.createViewer(document)
+        editor2.document.setReadOnly(true)
+        editor2.settings.apply {
+            isLineMarkerAreaShown = false
+            isIndentGuidesShown = false
+            isLineNumbersShown = false
+            isFoldingOutlineShown = false
+            isAllowSingleLogicalLineFolding = true
+            isAdditionalPageAtBottom = false
+            additionalColumnsCount = 0
+            additionalLinesCount = 0
+            isRightMarginShown = false
+            isCaretRowShown = false
+            isShowingSpecialChars = false
+        }
+
+        val markupModel = editor2.markupModel
+
+        text.highlights.forEach {
+            markupModel.addRangeHighlighter(it.startOffset, it.endOffset, 0, it.textAttributes, it.targetArea)
+        }
+
+        val lines = text.text.lines()
+
+        val contentSize = editor.component.visibleRect.size
+        val popupHeight = lines.size * editor.lineHeight
+        val component = object : JComponent() {
+            init {
+                layout = BorderLayout()
+
+                val scrollPane = ScrollPaneFactory.createScrollPane(editor2.contentComponent, true).apply {
+                    verticalScrollBarPolicy = JScrollPane.VERTICAL_SCROLLBAR_NEVER
+                    horizontalScrollBarPolicy = JScrollPane.HORIZONTAL_SCROLLBAR_NEVER
+                }
+                scrollPane.preferredSize = Dimension(contentSize.width, popupHeight)
+                add(scrollPane, BorderLayout.CENTER)
+            }
+        }
+
+
+        val popup = JBPopupFactory.getInstance()
+            .createComponentPopupBuilder(component, null)
+            .setFocusable(false)
+//            .setRequestFocus(false)
+            .setShowBorder(true)
+//            .setMovable(true)
+            .setMayBeParent(false)
+            .setCancelOnClickOutside(false)
+//            .setCancelOnWindowDeactivation(false)
+            .setCancelOnOtherWindowOpen(true)
+            .setCancelKeyEnabled(false)
+//            .addListener(object: JBPopupListener {
+//                override fun onClosed(event: LightweightWindowEvent) {
+//                    val commandState = CommandState.getInstance(editor)
+//                    commandState.mappingState.resetMappingSequence()
+//                    super.onClosed(event)
+//                }
+//            })
+            .createPopup()
+        popup.show(RelativePoint(editor.component, Point(0, contentSize.height - popupHeight)))
+        currentPopup = popup
+    }
+
+
+    private val keys = mapOf(
+        KeyEvent.VK_UP to "",
+        KeyEvent.VK_DOWN to "",
+        KeyEvent.VK_LEFT to "",
+        KeyEvent.VK_RIGHT to "",
+        KeyEvent.VK_ENTER to "󰌑",
+        KeyEvent.VK_ESCAPE to "󱊷",
+        KeyEvent.VK_BACK_SPACE to "󰁮",
+        KeyEvent.VK_SPACE to "󱁐",
+        KeyEvent.VK_TAB to "󰌒",
+        KeyEvent.VK_F1 to "󱊫",
+        KeyEvent.VK_F2 to "󱊬",
+        KeyEvent.VK_F3 to "󱊭",
+        KeyEvent.VK_F4 to "󱊮",
+        KeyEvent.VK_F5 to "󱊯",
+        KeyEvent.VK_F6 to "󱊰",
+        KeyEvent.VK_F7 to "󱊱",
+        KeyEvent.VK_F8 to "󱊲",
+        KeyEvent.VK_F9 to "󱊳",
+        KeyEvent.VK_F10 to "󱊴",
+        KeyEvent.VK_F11 to "󱊵",
+        KeyEvent.VK_F12 to "󱊶",
+    )
+
+    override fun showPopup(
+        editor: Editor,
+        typedKeys: List<KeyStroke>,
+        nestedMappings: List<Pair<String, Mapping>>,
+        startTime: Long
+    ) {
+        if (nestedMappings.isEmpty()) {
+            return
+        }
+        val items = Mappings.sort(nestedMappings).map {
+            val key = injector.parser.parseKeys(it.first).first()
+            val keyCode = if (key.keyCode == 0) KeyEvent.getExtendedKeyCodeForChar(key.keyChar.code) else key.keyCode
+            Item(
+                Modifiers.fromKeyStroke(key),
+                keys.getOrDefault(
+                    keyCode,
+                    if (key.keyCode == 0) key.keyChar.toString() else KeyEvent.getKeyText(key.keyCode)
+                ),
+                null,
+                it.second.description,
+                it.second.prefix
+            )
+        }
+        val text = PopupLayout.layoutItems(
+            40, editor.calculateSizeInCharacters()?.width ?: 50, WhichKeyConfig(), items
+        )
+        show(editor, text)
+        return
+    }
+}

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/NewPopupProvider.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/NewPopupProvider.kt
@@ -10,8 +10,12 @@ import eu.theblob42.idea.whichkey.model.Mapping
 import java.awt.*
 import javax.swing.*
 import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.editor.impl.EditorImpl
 import com.intellij.openapi.ui.popup.*
 import com.intellij.util.ui.UIUtil
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimDataType
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 import eu.theblob42.idea.whichkey.model.Mappings
 import eu.theblob42.idea.whichkey.provider.PopupProvider
@@ -33,6 +37,18 @@ val WHICHKEY_MAPPING_DESCRIPTION_GROUP = TextAttributesKey.createTextAttributesK
     DefaultLanguageHighlighterColors.KEYWORD
 )
 
+fun getConfig(name: String) : VimDataType? = injector.variableService.getGlobalVariableValue("WhichKey_${name}")
+
+fun getConfigInt(name: String) : Int? = when (val size = getConfig(name)) {
+    is VimInt -> size.value
+    else -> null
+}
+
+fun getConfigString(name: String) : String? = when (val size = getConfig(name)) {
+    is VimString -> size.value
+    else -> null
+}
+
 class NewPopupProvider: PopupProvider {
     companion object {
         const val name = "new"
@@ -43,6 +59,31 @@ class NewPopupProvider: PopupProvider {
         currentPopup = null
     }
 
+    private val fontSize: Int? // font size in point
+        get() = getConfigInt("FontSize")
+
+    private val padding: Int
+        get() = getConfigInt("Padding") ?: 1
+
+    private val paddingHorizontal: Int?
+        get() = getConfigInt("PaddingHorizontal")
+
+    private val paddingVertical: Int?
+        get() = getConfigInt("PaddingVertical")
+
+
+    private val margin: Int
+        get() = getConfigInt("Margin") ?: 1
+
+    private val marginHorizontal: Int?
+        get() = getConfigInt("MarginHorizontal")
+
+    private val marginVertical: Int?
+        get() = getConfigInt("MarginVertical")
+
+    private val spacing: Int
+        get() = getConfigInt("Spacing") ?: 3
+
     private val style: Style
         get() = when (val popupType = injector.variableService.getGlobalVariableValue("WhichKey_PopupStyle")) {
         !is VimString -> Style.BOTTOM
@@ -52,9 +93,13 @@ class NewPopupProvider: PopupProvider {
     private fun show(editor: Editor, items: List<Item>) {
         val rowWidth = 40
         val containerWidth = if (style == Style.RIGHT) rowWidth else editor.calculateSizeInCharacters()?.width ?: 50
-
+        val config = WhichKeyConfig(
+            spacing = spacing,
+            padding = DimensionConfig(paddingVertical ?: padding, paddingHorizontal ?: padding),
+            margin = DimensionConfig(marginVertical ?: margin, marginHorizontal ?: margin),
+        )
         val text = PopupLayout.layoutItems(
-            40, containerWidth, WhichKeyConfig(), items
+            40, containerWidth, config, items
         )
         val editorFactory: EditorFactory = EditorFactory.getInstance()
         val document = editorFactory.createDocument(text.text)
@@ -73,6 +118,9 @@ class NewPopupProvider: PopupProvider {
             isCaretRowShown = false
             isShowingSpecialChars = false
         }
+        fontSize?.let {
+            (editor2 as EditorImpl).fontSize = it
+        }
 
         val markupModel = editor2.markupModel
 
@@ -85,10 +133,14 @@ class NewPopupProvider: PopupProvider {
         val contentSize = editor.component.visibleRect.size
         val popupHeight = lines.size * editor.lineHeight
 
+        val charSize = editor.getCharSize()
+
+        val marginBottom = config.margin.vertical * editor.lineHeight
+        val marginRight = config.margin.horizontal * ceil(charSize.width).toInt()
 
         val preferredSize = when(style){
-            Style.BOTTOM -> Dimension(contentSize.width, popupHeight)
-            Style.RIGHT -> Dimension(rowWidth * ceil(editor.getCharSize().width).toInt(), popupHeight)
+            Style.BOTTOM -> Dimension(contentSize.width - 2*marginRight, popupHeight)
+            Style.RIGHT -> Dimension(rowWidth * ceil(charSize.width).toInt(), popupHeight)
         }
 
         val component = object : JComponent() {
@@ -126,11 +178,11 @@ class NewPopupProvider: PopupProvider {
             .createPopup()
         when(style) {
             Style.BOTTOM ->
-                popup.show(RelativePoint(editor.component, Point(0, contentSize.height - popupHeight)))
+                popup.show(RelativePoint(editor.component, Point(marginRight, contentSize.height - popupHeight - marginBottom)))
 
             Style.RIGHT -> {
                 val scrollbarPadding = UIUtil.getScrollBarWidth()
-                popup.show(RelativePoint(editor.component, Point(contentSize.width-preferredSize.width - scrollbarPadding, contentSize.height - popupHeight - scrollbarPadding)))
+                popup.show(RelativePoint(editor.component, Point(contentSize.width-preferredSize.width - scrollbarPadding - marginRight, contentSize.height - popupHeight - scrollbarPadding)))
             }
         }
         currentPopup = popup

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/NewPopupProvider.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/NewPopupProvider.kt
@@ -12,6 +12,7 @@ import javax.swing.*
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.ui.popup.*
 import com.intellij.util.ui.UIUtil
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 import eu.theblob42.idea.whichkey.model.Mappings
 import eu.theblob42.idea.whichkey.provider.PopupProvider
 import java.awt.event.KeyEvent
@@ -33,14 +34,22 @@ val WHICHKEY_MAPPING_DESCRIPTION_GROUP = TextAttributesKey.createTextAttributesK
 )
 
 class NewPopupProvider: PopupProvider {
+    companion object {
+        const val name = "new"
+    }
     private var currentPopup: JBPopup? = null
     override fun hidePopup() {
         currentPopup?.cancel()
         currentPopup = null
     }
 
+    private val style: Style
+        get() = when (val popupType = injector.variableService.getGlobalVariableValue("WhichKey_PopupStyle")) {
+        !is VimString -> Style.BOTTOM
+        else -> Style.entries.firstOrNull { it.name.compareTo(popupType.value, true) == 0 } ?: Style.BOTTOM
+    }
+
     private fun show(editor: Editor, items: List<Item>) {
-        val style = Style.RIGHT
         val rowWidth = 40
         val containerWidth = if (style == Style.RIGHT) rowWidth else editor.calculateSizeInCharacters()?.width ?: 50
 

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/PopupLayout.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/PopupLayout.kt
@@ -1,0 +1,198 @@
+package eu.theblob42.idea.whichkey.config
+
+import com.intellij.ide.ui.AntialiasingType
+import com.intellij.ide.ui.UISettings
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorFontType
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.impl.FontInfo
+import com.intellij.openapi.editor.impl.view.FontLayoutService
+import com.intellij.openapi.editor.markup.HighlighterTargetArea
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.util.ImageLoader
+import java.awt.event.KeyEvent
+import java.awt.font.FontRenderContext
+import javax.swing.KeyStroke
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.max
+import kotlin.math.min
+
+data class Modifier(val icon: String)
+object Modifiers {
+    private val icons = mapOf(
+        KeyEvent.CTRL_DOWN_MASK to Modifier("󰘴"),
+        KeyEvent.ALT_DOWN_MASK to Modifier("󰘵"),
+        KeyEvent.SHIFT_DOWN_MASK to Modifier("󰘶"),
+    )
+
+    fun fromKeyStroke(key: KeyStroke): List<Modifier> {
+        return icons.entries.filter { (it.key and key.modifiers) == it.key }.map { it.value }
+    }
+}
+
+data class Item(
+    val modifiers: List<Modifier>,
+    val code: String,
+    val icon: String?,
+    val description: String,
+    val isGroup: Boolean
+)
+
+data class Highlight(
+    val startOffset: Int,
+    val endOffset: Int,
+//            val layer: Int,
+    val textAttributes: TextAttributes?,
+    val targetArea: HighlighterTargetArea
+)
+
+data class TextWithHighlights(val text: String, val highlights: List<Highlight>)
+
+fun Editor.getCharSize(): ImageLoader.Dimension2DDouble {
+    val baseContext = FontInfo.getFontRenderContext(contentComponent)
+    val context = FontRenderContext(
+        baseContext.transform,
+        AntialiasingType.getKeyForCurrentScope(true),
+        UISettings.editorFractionalMetricsHint
+    )
+    val fontMetrics = FontInfo.getFontMetrics(colorsScheme.getFont(EditorFontType.PLAIN), context)
+    // Using the '%' to calculate the size as it's usually one of the widest non-double-width characters.
+    // For monospaced fonts this shouldn't really matter, but let's stay on the safe side.
+    // Otherwise, we may end up with some characters falsely displayed as double-width ones.
+    val width = FontLayoutService.getInstance().charWidth2D(fontMetrics, '%'.code)
+    return ImageLoader.Dimension2DDouble(width.toDouble(), lineHeight.toDouble())
+}
+
+data class EditorSizeInCharacters(val width: Int, val height: Int)
+
+fun Editor.calculateSizeInCharacters(): EditorSizeInCharacters? {
+//        val contentSize = scrollingModel.visibleArea.size
+    val contentSize = component.visibleRect.size
+    val charSize = getCharSize()
+
+    return if (contentSize.width > 0 && contentSize.height > 0) {
+        return EditorSizeInCharacters(
+            (contentSize.width / charSize.width).toInt(),
+            (contentSize.height / charSize.height).toInt()
+        )
+    } else null
+}
+
+object PopupLayout {
+    private fun dim(size: Int, parent: Int, vararg dims: SizeConfig): Int {
+        var adjustedSize = if (kotlin.math.abs(size) < 1) parent * size else size
+        adjustedSize = if (adjustedSize < 0) parent + adjustedSize else adjustedSize
+
+        for (dim in dims) {
+            val min = dim(dim.min, parent) ?: 0
+            val max = dim(dim.max, parent) ?: parent
+            adjustedSize = max(min, min(max, adjustedSize))
+        }
+        return floor(max(0, min(parent, adjustedSize)) + 0.5).toInt()
+    }
+
+    private fun makeExactly(str: String, widthInCodePoints: Int): String {
+        val builder = StringBuilder(str)
+        var len = builder.length
+        while (builder.codePointCount(0, len) > widthInCodePoints) {
+            len -= 1
+        }
+        while (builder.codePointCount(0, len) < widthInCodePoints) {
+            builder.append(' ')
+            len += 1
+        }
+        return builder.toString().substring(0, len - 1)
+    }
+
+    fun layoutItems(
+        maxRowWidth: Int,
+        containerWidth: Int,
+        config: WhichKeyConfig,
+        items: List<Item>,
+    ): TextWithHighlights {
+        val text = StringBuilder()
+        val highlights = mutableListOf<Highlight>()
+        var boxWidth = dim(maxRowWidth, containerWidth, config.width)
+        val boxCount = max((containerWidth / (boxWidth + config.spacing)), 1)
+        boxWidth = containerWidth / boxCount
+        val boxHeight = max(ceil(items.size.toDouble() / boxCount).toInt(), 2)
+
+        val scheme = EditorColorsManager.getInstance().globalScheme
+
+//    val rows = t.layout(LayoutParams(width = boxWidth - config.layout.spacing))
+
+        repeat(config.padding.first) {
+            text.append("\n")
+        }
+        fun appendWithHighlight(str: String, highlight: TextAttributesKey) {
+            highlights.add(
+                Highlight(
+                    text.length,
+                    text.length + str.length,
+                    scheme.getAttributes(highlight),
+                    HighlighterTargetArea.EXACT_RANGE
+                )
+            )
+            text.append(str)
+        }
+
+        val columns = items.withIndex().groupBy { it.index / boxHeight }
+
+        for (lineIndex in 0..boxHeight - 1) {
+            if (lineIndex > 0)
+                text.append("\n")
+            text.append(" ".repeat(config.padding.second))
+            for (b in 0..boxCount - 1) {
+                val i = b * boxHeight + lineIndex
+                val item = items.getOrNull(i)
+                if (b > 0) {
+                    text.append(" ".repeat(config.spacing))
+                }
+                if (item == null) {
+                    text.append(" ".repeat(boxWidth))
+                    continue
+                }
+                val column = columns[b]
+                val modifierSpaceRequired = column?.maxOf { it.value.modifiers.size } ?: 0
+                var nonDescriptionLength = 5 + modifierSpaceRequired
+                if (modifierSpaceRequired > 0) {
+                    text.append(" ".repeat(modifierSpaceRequired - item.modifiers.size))
+                    nonDescriptionLength++
+                }
+                for (mod in item.modifiers) {
+                    appendWithHighlight(mod.icon, WHICHKEY_MAPPING_BINDING)
+                }
+                if (modifierSpaceRequired > 0) {
+                    text.append(" ")
+                }
+                appendWithHighlight(item.code, WHICHKEY_MAPPING_BINDING)
+                appendWithHighlight(" ➜ ", WHICHKEY_MAPPING_ASSIGMENT)
+
+                val needsIconSpace = column?.any { it.value.icon != null } ?: false
+                if (needsIconSpace) {
+                    appendWithHighlight(item.icon ?: " ", WHICHKEY_MAPPING_ICON)
+                    text.append(" ")
+                    nonDescriptionLength += 2
+                }
+                val description = if (item.isGroup)
+                    "+${item.description}"
+                else
+                    item.description
+
+                appendWithHighlight(
+                    description,
+                    if (item.isGroup) WHICHKEY_MAPPING_DESCRIPTION_GROUP else WHICHKEY_MAPPING_DESCRIPTION
+                )
+                text.append(" ".repeat((boxWidth - description.length - nonDescriptionLength).coerceAtLeast(0)))
+            }
+            text.append(" ".repeat(config.padding.second))
+        }
+
+        repeat(config.padding.first) {
+            text.append("\n")
+        }
+        return TextWithHighlights(text.toString(), highlights)
+    }
+}

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/PopupLayout.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/PopupLayout.kt
@@ -123,7 +123,7 @@ object PopupLayout {
 
 //    val rows = t.layout(LayoutParams(width = boxWidth - config.layout.spacing))
 
-        repeat(config.padding.first) {
+        repeat(config.padding.vertical) {
             text.append("\n")
         }
         fun appendWithHighlight(str: String, highlight: TextAttributesKey) {
@@ -143,7 +143,7 @@ object PopupLayout {
         for (lineIndex in 0..boxHeight - 1) {
             if (lineIndex > 0)
                 text.append("\n")
-            text.append(" ".repeat(config.padding.second))
+            text.append(" ".repeat(config.padding.horizontal))
             for (b in 0..boxCount - 1) {
                 val i = b * boxHeight + lineIndex
                 val item = items.getOrNull(i)
@@ -187,10 +187,10 @@ object PopupLayout {
                 )
                 text.append(" ".repeat((boxWidth - description.length - nonDescriptionLength).coerceAtLeast(0)))
             }
-            text.append(" ".repeat(config.padding.second))
+            text.append(" ".repeat(config.padding.horizontal))
         }
 
-        repeat(config.padding.first) {
+        repeat(config.padding.vertical) {
             text.append("\n")
         }
         return TextWithHighlights(text.toString(), highlights)

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/WhichKeyConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/WhichKeyConfig.kt
@@ -1,0 +1,16 @@
+package eu.theblob42.idea.whichkey.config
+
+data class SizeConfig(val min: Int, val max: Int)
+
+data class WhichKeyConfig(
+    val height: SizeConfig = SizeConfig(min = 4, max = 25),
+    val width: SizeConfig = SizeConfig(min = 20, max = 50),
+    val spacing: Int = 3,
+    val padding: Pair<Int, Int> = Pair(0, 0)
+//    layout = {
+//        height = { min = 4, max = 25 }, -- min and max height of the columns
+//        width = { min = 20, max = 50 }, -- min and max width of the columns
+//        spacing = 3, -- spacing between columns
+//        align = "left", -- align columns left, center or right
+//    }
+)

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/WhichKeyConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/WhichKeyConfig.kt
@@ -2,11 +2,14 @@ package eu.theblob42.idea.whichkey.config
 
 data class SizeConfig(val min: Int, val max: Int)
 
+data class DimensionConfig(val vertical: Int, val horizontal: Int)
+
 data class WhichKeyConfig(
     val height: SizeConfig = SizeConfig(min = 4, max = 25),
     val width: SizeConfig = SizeConfig(min = 20, max = 50),
     val spacing: Int = 3,
-    val padding: Pair<Int, Int> = Pair(0, 0)
+    val padding: DimensionConfig = DimensionConfig(0, 0),
+    val margin: DimensionConfig = DimensionConfig(0, 0)
 //    layout = {
 //        height = { min = 4, max = 25 }, -- min and max height of the columns
 //        width = { min = 20, max = 50 }, -- min and max width of the columns

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/model/Mapping.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/model/Mapping.kt
@@ -1,7 +1,52 @@
 package eu.theblob42.idea.whichkey.model
 
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
+
 /**
  * @param prefix Indicator if this mapping is a prefix or an actual command
  * @param description A descriptive string for the mapping: category for a prefix ("Files"), descriptive name for a command ("close window") or the presentable String for a command ("<C-w>l")
  */
 data class Mapping(val prefix: Boolean, val description: String)
+
+object Mappings {
+    private val DEFAULT_SORT_OPTION = SortOption.BY_KEY
+    private val sortOption: SortOption
+        get() = when (val option = injector.variableService.getGlobalVariableValue("WhichKey_SortOrder")) {
+            null -> DEFAULT_SORT_OPTION
+            !is VimString -> DEFAULT_SORT_OPTION
+            else -> SortOption.values().firstOrNull { it.name.equals(option.asString(), ignoreCase = true) } ?: DEFAULT_SORT_OPTION
+        }
+
+    private const val DEFAULT_SORT_CASE_SENSITIVE = true
+    private val sortCaseSensitive: Boolean
+        get() = when (val option = injector.variableService.getGlobalVariableValue("WhichKey_SortCaseSensitive")) {
+            null -> DEFAULT_SORT_CASE_SENSITIVE
+            !is VimString -> DEFAULT_SORT_CASE_SENSITIVE
+            else -> option.asString().toBoolean()
+        }
+
+    enum class SortOption {
+        BY_KEY,
+        BY_KEY_PREFIX_FIRST,
+        BY_KEY_PREFIX_LAST,
+        BY_DESCRIPTION
+    }
+
+    /**
+     * Sort mappings dependent on the configured sort options
+     * @param nestedMappings The list of mappings to sort
+     * @return The sorted list of mappings
+     */
+    fun sort(nestedMappings: List<Pair<String, Mapping>>): List<Pair<String, Mapping>> {
+        // String::compareTo is by default case-sensitive
+        val cmp = if (sortCaseSensitive) String::compareTo else String.CASE_INSENSITIVE_ORDER::compare
+
+        return when (sortOption) {
+            SortOption.BY_KEY -> nestedMappings.sortedWith(compareBy(cmp) { it.first })
+            SortOption.BY_KEY_PREFIX_FIRST -> nestedMappings.sortedWith(compareBy<Pair<String, Mapping>> { !it.second.prefix }.thenBy(cmp) { it.first })
+            SortOption.BY_KEY_PREFIX_LAST -> nestedMappings.sortedWith(compareBy<Pair<String, Mapping>> { it.second.prefix }.thenBy(cmp) { it.first })
+            SortOption.BY_DESCRIPTION -> nestedMappings.sortedWith(compareBy(cmp) { it.second.description })
+        }
+    }
+}

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/provider/PopupProvider.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/provider/PopupProvider.kt
@@ -4,6 +4,9 @@ import com.intellij.openapi.application.EDT
 import com.intellij.openapi.editor.Editor
 import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
+import eu.theblob42.idea.whichkey.config.DefaultPopupProvider
+import eu.theblob42.idea.whichkey.config.NewPopupProvider
 import eu.theblob42.idea.whichkey.model.Mapping
 import kotlinx.coroutines.*
 import javax.swing.KeyStroke
@@ -18,8 +21,36 @@ interface PopupProvider {
     fun hidePopup()
 }
 
+class ConfigurablePopupProvider : PopupProvider {
+    private val defaultPopupProvider = DefaultPopupProvider()
+    private val alternativePopupProviders = mapOf(
+        NewPopupProvider.name to NewPopupProvider(),
+    )
+
+    private val debouncedPopupProvider = DebouncingPopupProvider {
+        when (val popupType = injector.variableService.getGlobalVariableValue("WhichKey_PopupType")) {
+            !is VimString -> defaultPopupProvider
+            else -> alternativePopupProviders.getOrDefault(popupType.value, defaultPopupProvider)
+        }
+    }
+
+    override fun showPopup(
+        editor: Editor,
+        typedKeys: List<KeyStroke>,
+        nestedMappings: List<Pair<String, Mapping>>,
+        startTime: Long
+    ) {
+        debouncedPopupProvider.showPopup(editor, typedKeys, nestedMappings, startTime)
+    }
+
+    override fun hidePopup() {
+        debouncedPopupProvider.hidePopup()
+    }
+
+}
+
 @OptIn(DelicateCoroutinesApi::class)
-class DebouncingPopupProvider(private val provider: PopupProvider) : PopupProvider {
+class DebouncingPopupProvider(private val provider: () -> PopupProvider) : PopupProvider {
     private val DEFAULT_POPUP_DELAY = 200L
     private val defaultPopupDelay: Long
         get() = when (val delay = injector.variableService.getGlobalVariableValue("WhichKey_DefaultDelay")) {
@@ -40,12 +71,12 @@ class DebouncingPopupProvider(private val provider: PopupProvider) : PopupProvid
          */
         val delay = (defaultPopupDelay - (System.currentTimeMillis() - startTime)).coerceAtLeast(0)
         when (delay) {
-            0L -> provider.showPopup(editor, typedKeys, nestedMappings, startTime)
+            0L -> provider().showPopup(editor, typedKeys, nestedMappings, startTime)
             else -> {
                 debounceJob = GlobalScope.launch {
                     delay(delay)
                     withContext(Dispatchers.EDT) {
-                        provider.showPopup(editor, typedKeys, nestedMappings, startTime)
+                        provider().showPopup(editor, typedKeys, nestedMappings, startTime)
                     }
                 }
             }
@@ -56,7 +87,7 @@ class DebouncingPopupProvider(private val provider: PopupProvider) : PopupProvid
         runBlocking {
             debounceJob?.cancelAndJoin()
         }
-        provider.hidePopup()
+        provider().hidePopup()
     }
 
 }

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/provider/PopupProvider.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/provider/PopupProvider.kt
@@ -1,0 +1,62 @@
+package eu.theblob42.idea.whichkey.provider
+
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.editor.Editor
+import com.maddyhome.idea.vim.api.injector
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
+import eu.theblob42.idea.whichkey.model.Mapping
+import kotlinx.coroutines.*
+import javax.swing.KeyStroke
+
+interface PopupProvider {
+    fun showPopup(
+        editor: Editor,
+        typedKeys: List<KeyStroke>,
+        nestedMappings: List<Pair<String, Mapping>>,
+        startTime: Long,
+    )
+    fun hidePopup()
+}
+
+@OptIn(DelicateCoroutinesApi::class)
+class DebouncingPopupProvider(private val provider: PopupProvider) : PopupProvider {
+    private val DEFAULT_POPUP_DELAY = 200L
+    private val defaultPopupDelay: Long
+        get() = when (val delay = injector.variableService.getGlobalVariableValue("WhichKey_DefaultDelay")) {
+            null -> DEFAULT_POPUP_DELAY
+            !is VimInt -> DEFAULT_POPUP_DELAY
+            else -> delay.value.toLong()
+        }
+    private var debounceJob: Job? = null
+    override fun showPopup(
+        editor: Editor,
+        typedKeys: List<KeyStroke>,
+        nestedMappings: List<Pair<String, Mapping>>,
+        startTime: Long
+    ) {
+        /*
+         * wait for a few ms before showing the Balloon to prevent flickering on fast consecutive key presses
+         * subtract the already passed time (for calculations etc.) to make the delay as consistent as possible
+         */
+        val delay = (defaultPopupDelay - (System.currentTimeMillis() - startTime)).coerceAtLeast(0)
+        when (delay) {
+            0L -> provider.showPopup(editor, typedKeys, nestedMappings, startTime)
+            else -> {
+                debounceJob = GlobalScope.launch {
+                    delay(delay)
+                    withContext(Dispatchers.EDT) {
+                        provider.showPopup(editor, typedKeys, nestedMappings, startTime)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun hidePopup() {
+        runBlocking {
+            debounceJob?.cancelAndJoin()
+        }
+        provider.hidePopup()
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,4 +45,14 @@
         <vimExtension implementation="eu.theblob42.idea.whichkey.WhichKeyExtension" name="which-key"/>
     </extensions>
 
+    <extensions defaultExtensionNs="com.intellij">
+        <additionalTextAttributes
+                scheme="Default"
+                file="colorSchemes/WhichKeyDefault.xml"/>
+        <additionalTextAttributes
+                scheme="Darcula"
+                file="colorSchemes/WhichKeyDarcula.xml"/>
+        <!--                <colorSettingsPage implementation="org.intellij.erlang.editor.ErlangColorSettingsPage"/>-->
+    </extensions>
+
 </idea-plugin>

--- a/src/main/resources/colorSchemes/WhichKeyDarcula.xml
+++ b/src/main/resources/colorSchemes/WhichKeyDarcula.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--        val WHICHKEY_MAPPING_BINDING = TextAttributesKey.createTextAttributesKey("WHICHKEY_MAPPING_BINDING", DefaultLanguageHighlighterColors.KEYWORD)-->
+<!--        val WHICHKEY_MAPPING_ASSIGMENT = TextAttributesKey.createTextAttributesKey("WHICHKEY_MAPPING_ASSIGMENT", DefaultLanguageHighlighterColors.OPERATION_SIGN)-->
+<!--        val WHICHKEY_MAPPING_ICON = TextAttributesKey.createTextAttributesKey("WHICHKEY_MAPPING_ICON", DefaultLanguageHighlighterColors.OPERATION_SIGN)-->
+<!--        val WHICHKEY_MAPPING_DESCRIPTION = TextAttributesKey.createTextAttributesKey("WHICHKEY_MAPPING_DESCRIPTION", DefaultLanguageHighlighterColors.IDENTIFIER)-->
+<list>
+    <option name="WHICHKEY_MAPPING_BINDING">
+        <value>
+            <option name="FOREGROUND" value="66A6BE"/>
+        </value>
+    </option>
+    <option name="WHICHKEY_MAPPING_ASSIGMENT">
+        <value>
+            <option name="FOREGROUND" value="636DA6"/>
+        </value>
+    </option>
+    <option name="WHICHKEY_MAPPING_ICON">
+        <value>
+            <option name="FOREGROUND" value="636DA6"/>
+        </value>
+    </option>
+    <option name="WHICHKEY_MAPPING_DESCRIPTION">
+        <value>
+            <option name="FOREGROUND" value="C099FF"/>
+        </value>
+    </option>
+</list>

--- a/src/main/resources/colorSchemes/WhichKeyDefault.xml
+++ b/src/main/resources/colorSchemes/WhichKeyDefault.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<list>
+    <option name="WHICHKEY_MAPPING_BINDING">
+        <value>
+            <option name="FOREGROUND" value="DCF2B0"/>
+        </value>
+    </option>
+    <option name="WHICHKEY_MAPPING_ASSIGMENT">
+        <value>
+            <option name="FOREGROUND" value="c2eabd"/>
+        </value>
+    </option>
+    <option name="WHICHKEY_MAPPING_ICON">
+        <value>
+            <option name="FOREGROUND" value="c0babc"/>
+        </value>
+    </option>
+    <option name="WHICHKEY_MAPPING_DESCRIPTION">
+        <value>
+            <option name="FOREGROUND" value="c7ac92"/>
+        </value>
+    </option>
+</list>


### PR DESCRIPTION
Aims to fix https://github.com/TheBlob42/idea-which-key/issues/97 (customization not fully implemented yet).

It is rebuilt using an embedded code editor instead of a html view in order to "blend in" better with the content you are working on. The original idea was to align the characters in the popup pixel-perfect with the characters of the main code editor, but I got lazy :D

I extracted an interface for showing the popup so that users can choose the "traditional" popup or this new one.

The work isn't done yet, but I wanted to get some feedback on how it works for other people and if they like it.

- [x] "icon" support (nerd fonts)
- [x] modifiers rendered as icons instead of text 
- [x] different styles: bottom or right side
- [ ] color support per item
- [ ] allow to configure default colors (settings dialog?/config)
- [x] allow configuring layout (settings dialog?/config)
- [ ] add prefix info rendering and ESC hint at the bottom
- [ ] add new style for "bottom of ide" (out of editor), more or less like current popup
- [ ] come up with a solution for popup that becomes too large to fit on screen. pagination like which-key.nvim and the ideavim bottom panel?


This is how it looks on my machine:

bottom positioning:
![image](https://github.com/user-attachments/assets/0c75810e-19d7-4240-aef6-7636da3e3d0e)

right side positioning (single columns):
![image](https://github.com/user-attachments/assets/c5c8a027-23cd-441c-97a5-f310920f20e4)

