### PR TITLE
Streamline the messageBus implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed
+
+- Refactor to use `AnActionListener` on the [Message Bus](https://plugins.jetbrains.com/docs/intellij/messaging-infrastructure.html#message-bus)
+  - Enables proper functionality for special keys like `<C-c>`, `<M-c>`, `<Esc>`
+  - Fixes **the** big know issues of the plugin
+  - Fixes [#52](https://github.com/TheBlob42/idea-which-key/issues/52) and [#81](https://github.com/TheBlob42/idea-which-key/issues/81)
+
 ## 0.10.3
 
 ### Changed
@@ -43,7 +50,7 @@
 - New `g:WhichKey_SortCaseSensitive` variable
   - Controls if the sorting of elements in the popup should be case-sensitive or not (default: `true`)
 
-### Changes
+### Changed
 
 - Fix missing getters for several properties to make them reloadable without restart
   - `WhichKey_DefaultDelay`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
   - Enables proper functionality for special keys like `<C-c>`, `<M-c>`, `<Esc>`
   - Fixes **the** big know issues of the plugin
   - Fixes [#52](https://github.com/TheBlob42/idea-which-key/issues/52) and [#81](https://github.com/TheBlob42/idea-which-key/issues/81)
+- Properly check for recursive mappings
+  - Fixes [#71](https://github.com/TheBlob42/idea-which-key/issues/71)
+  ```vim
+  nnoremap <space>abc :action ShowTips<CR>
+  " , should trigger the popup showing the 'a' prefix as next option
+  nmap , <space>
+  " ; should NOT trigger the popup but instead execute the 'original' mapping for <space>
+  nnoremap ; <space>
+  ```
 
 ## 0.10.3
 

--- a/README.md
+++ b/README.md
@@ -157,15 +157,10 @@ let g:WhichKey_ProcessUnknownMappings = "false"
 <details>
 <summary><b>Caveats</b></summary>
 
-##### Insert Mode
+##### Insert & Operator-Pending Mode
 
-This will never block insert mode mappings in order to enable mappings like `imap jk <Esc>` without interfering with characters you actually want to type. It also should¹ not interfere with operator commands or motions which are not "real" mappings like `hjkl`, `d`, `f`, etc.
+This will never block insert mode mappings in order to enable mappings like `imap jk <Esc>` without interfering with characters you actually want to type. Similar we also do not block any operator-pending mode key presses (e.g. for `d`, `f` etc.)
 
-¹*If you encounter any weird behavior please open an issue, as there might be edge cases not covered yet*
-
-##### Ending On A Special Key
-
-If you end your "unknown key sequence" on a special key (`<Esc>`, `<Tab>`, any combination with `Control`, `Alt` etc.) this option will not work as expected and your previous keys will still be executed. The reason is that Which-Key can't intercept those key presses and does not realize that it should not process any previous keys. See also the [Known Issues](#known-issues) section for more information on the matter
 </details>
 
 ### Order
@@ -215,28 +210,12 @@ You can configure the appearance of certain UI elements by setting the following
 
 ## Known Issues
 
-The way the plugin injects itself into the flow of IdeaVIM to provide its features is a little "hacky" and you might encounter some inconsistencies. If you encounter anything not documented open an issue so we can check and maybe fix it. These are the ones that I am aware of
+### Easymotion
 
-### Special Prefixes
+If you are using the [easymotion](https://github.com/AlexPl292/IdeaVim-EasyMotion) plugin you might see the popup being displayed when you want to select a label for a key that also starts a multi key mapping:
 
-Consider the following mapping sequence example which contains a modified key press (`<C-a>`) within:
+- Configure a multi key mapping like `nnoremap gt :action ShowTips<CR>`
+- Trigger any easymotion mapping like `<Plug>(easymotion-s)`
+- Pressing `g` will now trigger the popup and "block" your view
 
-> What the mapping does is not important for the example
-
-```text
-noremap g<C-a>bc ...
-```
-
-If you are about to activate this mapping the following will happen:
-
-| Press   | What will happen                                   |
-| ---     | ---                                                |
-| `g`     | The popup will appear and show `<C-a>` as a prefix |
-| `<C-a>` | The popup will close itself                        |
-| `b`     | The popup will reopen and show `c` as a command    |
-| `c`     | This will close the popup and execute your mapping |
-
-
-The reason for this is that we currently have no way to intercept modified & special key presses like `<C-a>`, `<Esc>`, `<A-a>` etc. Vim internal actions like `<C-d>` or `<C-o>` are handled as a custom action instead of being processed by a general handler like "regular" key presses
-
-If you have more knowledge about the internals of IdeaVIM in this regard or have another idea how to solve this issue, please open an issue or PR
+So far there is no workaround for this issues, but a fix is planned once I figure it out

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/config/MappingConfig.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/config/MappingConfig.kt
@@ -107,7 +107,9 @@ object MappingConfig {
             replacedKeyStrokes.add(keyStroke)
             val mapping = injector.keyGroup.getKeyMapping(mode)[replacedKeyStrokes]
 
-            if (mapping != null && mapping is ToKeysMappingInfo) {
+            if (mapping != null
+                && mapping is ToKeysMappingInfo
+                && mapping.isRecursive) {
                 replacedKeyStrokes = mapping.toKeys.toMutableList()
             }
         }
@@ -120,6 +122,7 @@ object MappingConfig {
         val sequenceMapping = injector.keyGroup.getKeyMapping(mode)[keyStrokes]
         if (sequenceMapping != null
             && sequenceMapping is ToKeysMappingInfo
+            && sequenceMapping.isRecursive
             && sequenceMapping.toKeys != replacedKeyStrokes){
             nestedMappings.putAll(extractNestedMappings(mode, sequenceMapping.toKeys,whichKeyDescriptions))
         }


### PR DESCRIPTION
- Properly block when ProcessUnknownMappings is set to "false"
- Handle shifted characters
- Handle prefix count input
- Fix space handling for multi key mappings (e.g. `<space><space>`)
- General refactoring

Test this extensively in "real world usage" to be sure that I have not overlooked any issue here. There is one known issue in combination with the [easymotion](https://github.com/AlexPl292/IdeaVim-EasyMotion) plugin where the popup will trigger for key strokes meant to filter or jump to a label. If I can fix this here it would be nice, but otherwise we can take care of this later

@davfsa & @luqasn I would like to get this through before checking your other PRs so we have a working baseline, you might need to rebase your PRs afterwards. Sorry that it took me so long