### PR TITLE
Disable popup for non-file-based editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,3 +219,12 @@ If you are using the [easymotion](https://github.com/AlexPl292/IdeaVim-EasyMotio
 - Pressing `g` will now trigger the popup and "block" your view
 
 So far there is no workaround for this issues, but a fix is planned once I figure it out
+
+### Non-File-Based Editors
+
+Since version `2.25.1` IdeaVIM is not active in any non-file-based editors with the following exceptions ([issue](https://youtrack.jetbrains.com/issue/VIM-3929)):
+
+- The GIT commit window
+- The diff viewer
+
+The Which-Key plugin matches this behavior **but** without any exceptions in order to keep the implementation simple (this might change in the future)

--- a/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyActionListener.kt
+++ b/src/main/kotlin/eu/theblob42/idea/whichkey/WhichKeyActionListener.kt
@@ -14,6 +14,7 @@ import com.maddyhome.idea.vim.api.injector
 import com.maddyhome.idea.vim.command.Argument
 import com.maddyhome.idea.vim.command.MappingMode
 import com.maddyhome.idea.vim.command.MappingState
+import com.maddyhome.idea.vim.helper.EditorHelper
 import com.maddyhome.idea.vim.impl.state.toMappingMode
 import com.maddyhome.idea.vim.newapi.vim
 import com.maddyhome.idea.vim.options.OptionAccessScope
@@ -64,6 +65,10 @@ class WhichKeyActionListener : AnActionListener {
         }
 
         val editor = dataContext.getData(CommonDataKeys.EDITOR) ?: return
+        if (!EditorHelper.isFileEditor(editor)) {
+            return
+        }
+
         val keyHandlerState = KeyHandler.getInstance().keyHandlerState
         val mappingState = keyHandlerState.mappingState
         val vimCurrentKeySequence = mappingState.keys.toList().ifEmpty { keyHandlerState.commandBuilder.keys.toList() }
@@ -89,7 +94,11 @@ class WhichKeyActionListener : AnActionListener {
 
     override fun beforeEditorTyping(charTyped: Char, dataContext: DataContext) {
         PopupConfig.hidePopup()
+
         val editor = dataContext.getData(CommonDataKeys.EDITOR) ?: return
+        if (!EditorHelper.isFileEditor(editor)) {
+            return
+        }
 
         val keyHandlerState = KeyHandler.getInstance().keyHandlerState
 


### PR DESCRIPTION
Match the behavior of IdeaVIM since version 2.25.1 with the difference that we make no exceptions to this rule (e.g. diff viewer & git commit window) to keep things simple and consistent.

Fixes #104 